### PR TITLE
fix:Update LibGUI from 8.0.0 to 8.1.1 for Minecraft 1.20.1.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,10 +8,10 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.21
 
 # Mod Properties
-	mod_version=2.0.0
+	mod_version=2.0.0.1
 	maven_group=io.github.cyberanner.ironchests
 	archives_base_name=IronChests
 
 # Dependencies
     fabric_version=0.83.1+1.20.1
-	libgui_version=8.0.0+1.20
+	libgui_version=8.1.1+1.20.1


### PR DESCRIPTION
Update LibGUI from 8.0.0 to 8.1.1 for Minecraft 1.20.1.
Fixed #62 #61 .