### PR TITLE
Add tags for new FastChest tag-based API

### DIFF
--- a/src/main/resources/data/fastchest/tags/block/compatible_chests.json
+++ b/src/main/resources/data/fastchest/tags/block/compatible_chests.json
@@ -1,0 +1,13 @@
+{
+  "replace": false,
+  "values": [
+    "ironchest:christmas_chest",
+    "ironchest:copper_chest",
+    "ironchest:diamond_chest",
+    "ironchest:emerald_chest",
+    "ironchest:gold_chest",
+    "ironchest:iron_chest",
+    "ironchest:netherite_chest",
+    "ironchest:obsidian_chest"
+  ]
+}

--- a/src/main/resources/data/fastchest/tags/block_entity_type/compatible_chests.json
+++ b/src/main/resources/data/fastchest/tags/block_entity_type/compatible_chests.json
@@ -1,0 +1,13 @@
+{
+  "replace": false,
+  "values": [
+    "ironchest:christmas_chest",
+    "ironchest:copper_chest",
+    "ironchest:diamond_chest",
+    "ironchest:emerald_chest",
+    "ironchest:gold_chest",
+    "ironchest:iron_chest",
+    "ironchest:netherite_chest",
+    "ironchest:obsidian_chest"
+  ]
+}


### PR DESCRIPTION
I've added tags in FastChest to remove the hardcoded compatibility logic. At the moment there is a `required = false` copy of these entries in FastChest, but since IronChests is providing models for compatibility the tags should also be declared here.

As long as the 1.20.2 FastChest build keeps working on new Minecraft versions, I'll keep the tags in.